### PR TITLE
Support Wayland when editing configs

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -208,14 +208,18 @@ class MainWindow(QWidget):
 
         # 1. Open WITHOUT root via GVFS backend admin://
 
-        cmd = [
-            "env",
-            f"DISPLAY={os.environ.get('DISPLAY')}",
-            f"XAUTHORITY={os.environ.get('XAUTHORITY')}",
-            f"DBUS_SESSION_BUS_ADDRESS={os.environ.get('DBUS_SESSION_BUS_ADDRESS', '')}",
-            "xdg-open",
-            str(conf),
-        ]
+        cmd = ["env"]
+        for var in (
+            "DISPLAY",
+            "XAUTHORITY",
+            "DBUS_SESSION_BUS_ADDRESS",
+            "WAYLAND_DISPLAY",
+            "XDG_RUNTIME_DIR",
+        ):
+            val = os.environ.get(var)
+            if val:
+                cmd.append(f"{var}={val}")
+        cmd.extend(["xdg-open", str(conf)])
         _, err = _run_command(cmd, use_root=True)
 
         if err:


### PR DESCRIPTION
## Summary
- allow launching the editor from Wayland sessions in `gui.py`

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6876078a236c8329bf96efc067aa57fe