### PR TITLE
Add post-install automation for Debian package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+*.deb

--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ sudo ./install.sh
 ```
 
 The script installs the `wireguard` and `firejail` packages, creates the `novpn` group and adds your user to it, configures an IP rule for that group, and allows root GUI applications via `xhost` for both X11 and Wayland sessions.
+
+When installing the Debian package built with `build_deb.sh`, this setup script
+is executed automatically so no additional steps are required.
+
+## Building a Debian package
+
+Use the provided `build_deb.sh` script to create a `.deb` installer. You can optionally pass a version number:
+
+```bash
+./build_deb.sh 0.1.0
+```
+
+The resulting `wireguard-ui_<version>_all.deb` will be created in the current directory and can be installed with `dpkg -i` on Ubuntu or Linux Mint.

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Build a simple .deb package for wireguard-ui.
+
+set -e
+
+version="${1:-0.1.0}"
+pkg="wireguard-ui"
+build_dir="$(mktemp -d)"
+pkg_dir="$build_dir/${pkg}_${version}"
+
+mkdir -p "$pkg_dir/DEBIAN" \
+         "$pkg_dir/usr/share/${pkg}" \
+         "$pkg_dir/usr/bin" \
+         "$pkg_dir/usr/share/applications" \
+         "$pkg_dir/usr/share/icons/hicolor/256x256/apps"
+
+cat > "$pkg_dir/DEBIAN/control" <<CONTROL
+Package: ${pkg}
+Version: ${version}
+Section: utils
+Priority: optional
+Architecture: all
+Depends: python3, python3-pyqt6, python3-xdg, wireguard, firejail
+Maintainer: $(git config user.email || echo "unknown@example.com")
+Description: Simple WireGuard GUI
+CONTROL
+
+cp -r src "$pkg_dir/usr/share/${pkg}/"
+install -m 755 install.sh "$pkg_dir/usr/share/${pkg}/install.sh"
+
+cat > "$pkg_dir/DEBIAN/postinst" <<'POSTINST'
+#!/bin/bash
+set -e
+/usr/share/wireguard-ui/install.sh
+POSTINST
+chmod 755 "$pkg_dir/DEBIAN/postinst"
+
+cat > "$pkg_dir/usr/bin/${pkg}" <<'SCRIPT'
+#!/bin/bash
+exec python3 /usr/share/wireguard-ui/src/main.py "$@"
+SCRIPT
+chmod +x "$pkg_dir/usr/bin/${pkg}"
+
+cat > "$pkg_dir/usr/share/applications/${pkg}.desktop" <<DESKTOP
+[Desktop Entry]
+Type=Application
+Name=WireGuard UI
+Exec=/usr/bin/${pkg}
+Icon=${pkg}
+Terminal=false
+Categories=Network;
+DESKTOP
+
+install -m 644 src/icons/icon.ico "$pkg_dir/usr/share/icons/hicolor/256x256/apps/${pkg}.ico"
+
+dpkg-deb --build "$pkg_dir" "$build_dir/${pkg}_${version}_all.deb"
+
+mv "$build_dir/${pkg}_${version}_all.deb" .
+
+echo "Created ${pkg}_${version}_all.deb"


### PR DESCRIPTION
## Summary
- run `install.sh` automatically when the `.deb` is installed
- add package dependencies for `wireguard` and `firejail`
- update README to mention automatic post-installation

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `./build_deb.sh 0.1.1`


------
https://chatgpt.com/codex/tasks/task_e_687608efc7d4832994f9f7621c70eb96