### PR TITLE
Automatically clean desktop Exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,15 @@ Run the provided `install.sh` as root to install required packages and configure
 sudo ./install.sh
 ```
 
-The script installs the `wireguard` and `firejail` packages, creates the `novpn` group and adds your user to it, configures an IP rule for that group, and allows root GUI applications via `xhost` for both X11 and Wayland sessions. When run during package installation and no non-root user is detected, user-specific steps are skipped automatically.
+The script installs the `wireguard` and `firejail` packages, creates the `novpn` group and adds your user to it, configures an IP rule for that group, and allows root GUI applications via `xhost` for both X11 and Wayland sessions. When run during package installation and no non-root user is detected, user-specific steps are skipped automatically. The installer also invokes `patch_desktop_exec.sh` which removes any `sudo` or `pkexec` prefixes from the program's `.desktop` file so the GUI starts as your normal user.
 
 When installing the Debian package built with `build_deb.sh`, this setup script
 is executed automatically so no additional steps are required.
+
+During installation a helper script automatically cleans the
+`/usr/share/applications/wireguard-ui.desktop` entry so the application starts
+under the regular user instead of `root`. This prevents losing your GTK theme
+and icons when launching from the desktop menu.
 
 ## Building a Debian package
 

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -27,6 +27,7 @@ CONTROL
 
 cp -r src "$pkg_dir/usr/share/${pkg}/"
 install -m 755 install.sh "$pkg_dir/usr/share/${pkg}/install.sh"
+install -m 755 patch_desktop_exec.sh "$pkg_dir/usr/share/${pkg}/patch_desktop_exec.sh"
 
 cat > "$pkg_dir/DEBIAN/postinst" <<'POSTINST'
 #!/bin/bash

--- a/install.sh
+++ b/install.sh
@@ -55,3 +55,11 @@ if [[ "$skip_user_setup" == false && ("$session_type" == "x11" || "$session_type
 fi
 
 echo "Setup complete."
+
+# Fix the application's .desktop file to avoid running as root when launched
+# from the desktop menu. Removes possible `pkexec` or `sudo` wrappers in the
+# Exec line if present.
+desktop_file="/usr/share/applications/wireguard-ui.desktop"
+if [ -f "$desktop_file" ]; then
+    /usr/share/wireguard-ui/patch_desktop_exec.sh "$desktop_file" || true
+fi

--- a/patch_desktop_exec.sh
+++ b/patch_desktop_exec.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Fix .desktop Exec line to remove pkexec or sudo prefixes
+# Usage: ./patch_desktop_exec.sh /path/to/file.desktop
+set -e
+
+file="$1"
+if [[ -z "$file" || ! -f "$file" ]]; then
+    echo "Usage: $0 /path/to/file.desktop" >&2
+    exit 1
+fi
+
+exec_line=$(grep -m1 '^Exec=' "$file" || true)
+if [[ -z "$exec_line" ]]; then
+    exit 0
+fi
+
+cmd=${exec_line#Exec=}
+# remove leading pkexec or sudo and trailing arguments like pkexec env ...
+cmd=${cmd#pkexec }
+cmd=${cmd#sudo }
+# remove 'env ' if used with pkexec env
+if [[ $cmd == env* ]]; then
+    cmd=${cmd#env }
+fi
+sed -i "s|^Exec=.*|Exec=$cmd|" "$file"


### PR DESCRIPTION
## Summary
- add a helper script `patch_desktop_exec.sh` to strip `sudo` or `pkexec` from a `.desktop` file
- install this script when building the package
- invoke it from `install.sh` to sanitize `wireguard-ui.desktop`
- document the behaviour in the README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68762c82b7e0832995cbfc7d187c7ad8